### PR TITLE
Create admin user even if replication is disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: configure MongoDB admin user
   include: admin.yml
-  when: mongodb_replSet_isMaster
+  when: mongodb_replSet_isMaster or not mongodb_replSet_enabled
   tags: mongodb_admin
 
 - name: configure MongoDB replication


### PR DESCRIPTION
I browsed through a number on MongoDB roles from Ansible Galaxy, yours looked really nice so I gave it a try. 

On a single machine with replication disabled I noticed that admin user was not created. This pull request fixes that.

Otherwise this role looks great, thanks for publishing it!