### PR TITLE
Ensure that mongod user has no shell access

### DIFF
--- a/tasks/install.common.yml
+++ b/tasks/install.common.yml
@@ -18,6 +18,7 @@
   user:
     name: "{{ mongodb_daemon_user }}"
     group: "{{ mongodb_daemon_group }}"
+    shell: /bin/false
     state: present
 
 - name: create mongodb-writable directories


### PR DESCRIPTION
Mongod user's shell is set to /bin/false when the user is created by rpm or dep package installer. Now that the user is created before installing the package shell is not set. This PR sets shell explicitly so that the service user doesn't have shell access. 

If you run this on a server that was set up before aa05ee402407d3dd9cef700a00e736ddec2c57d5 "configure mongodb user" task should not change anything.