### PR TITLE
Support overriding replica set member IP

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ mongodb_replSet_enabled: false
 mongodb_replSet_name: ""
 mongodb_replSet_master: "127.0.0.1"
 mongodb_replSet_isMaster: false
+mongodb_replSet_member: "{{ ansible_default_ipv4.address }}"
 
 mongodb_shell_run: false
 mongodb_shell_commands: {}                             # Define mongo shell commands to run

--- a/tasks/replica.yml
+++ b/tasks/replica.yml
@@ -8,7 +8,7 @@
     login_user: "{{ mongodb_admin_user }}"
     login_password: "{{ mongodb_admin_password }}"
     priority: "501"
-    member: "{{ ansible_default_ipv4.address }}:{{ mongodb_conf_port }}"
+    member: "{{ mongodb_replSet_member }}:{{ mongodb_conf_port }}"
   when: mongodb_replSet_isMaster
 
 - name: connect to master
@@ -19,5 +19,5 @@
     login_port: "{{ mongodb_conf_port }}"
     login_user: "{{ mongodb_admin_user }}"
     login_password: "{{ mongodb_admin_password }}"
-    member: "{{ ansible_default_ipv4.address }}:{{ mongodb_conf_port }}"
+    member: "{{ mongodb_replSet_member }}:{{ mongodb_conf_port }}"
   when: not mongodb_replSet_isMaster


### PR DESCRIPTION
If the server has multiple network interfaces, it might be desired or even necessary to use some other that the default interface for replica set communication. This PR adds a variable that can be overridden on playbooks.

For example:
```
roles:
    - stone-payments.mongodb
vars:
    my_mongodb_interface: eth1
    mongodb_replSet_member:  "{{ hostvars[inventory_hostname]['ansible_' + my_mongodb_interface].ipv4.address }}"
```