### PR TITLE
Connect to Ubuntu keyserver port 80

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,6 +1,6 @@
 - name: Import the key for the official MongoDB repository.
   apt_key:
-    keyserver: keyserver.ubuntu.com
+    keyserver: hkp://keyserver.ubuntu.com:80
     id: 0C49F3730359A14518585931BC711F9BA15703C6
 
 - name: Setup Debian MongoDB {{ mongodb_install_major }}.{{ mongodb_install_minor }} repository


### PR DESCRIPTION
Port 80 works more robustly if outbound connections are filtered. In my case, a firewall blocked connection to the default port. 

This connection string matches [MongoDB installation guide](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/#import-the-public-key-used-by-the-package-management-system). The original syntax was from Ansible [apt_key module examples](http://docs.ansible.com/ansible/latest/apt_key_module.html#examples).