### PR TITLE
Support setting any systemLog option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,22 @@ connect to. You can do all this with the following excerpt:
     mongodb_replSet_master: "1.2.3.4"
     mongodb_replSet_isMaster: "{{ true if mongodb_replSet_master in ansible_all_ipv4_addresses else false }}"
 ```
-
+### Logging
+You can set any [systemLog](https://docs.mongodb.com/manual/reference/configuration-options/#systemlog-options)
+option by providing `mongodb_conf_logging` dictionary:
+```
+- name: install mongodb with network debug logging
+  host: all
+  roles: stone-payments.mongodb
+  vars:
+    mongodb_conf_logging:
+      verbosity: 0
+      component:
+        network:
+          verbosity: 5
+      destination: file
+      path: /var/log/mongodb/mongod.log
+```
 ### Other configs
 I believe almost every other config is self-explanatory or directly related to a MongoDB core feature. Simply override
 the configs on `defaults/main.yml` and they will be (hopefully) applied to your system.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,10 +21,10 @@ mongodb_conf_cpu: yes                                  # Periodically show cpu a
 mongodb_conf_httpInterface: false                      # Enable (deprecated) http interface
 mongodb_conf_ipv6: false                               # Enable IPv6 support
 mongodb_conf_journal: true                             # Enable journaling
-mongodb_conf_verbosity: 1
+mongodb_conf_logging: "{{ mongodb_conf_logging_defaults }}" # systemLog settings dictionary
+mongodb_conf_verbosity: 1                              # Verbosity when mongodb_conf_logging_defaults is used
 mongodb_conf_maxConns: 800                             # Max number of simultaneous connections
 mongodb_conf_port: 27017                               # Specify TCP port number
-mongodb_conf_sysLog: false                             # Log to system's syslog facility instead of file (ignored if logpath set)
 mongodb_conf_oplogSize: 1024
 mongodb_conf_key: ""                                   # Keyfile content
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,6 @@ mongodb_conf_httpInterface: false                      # Enable (deprecated) htt
 mongodb_conf_ipv6: false                               # Enable IPv6 support
 mongodb_conf_journal: true                             # Enable journaling
 mongodb_conf_logging: "{{ mongodb_conf_logging_defaults }}" # systemLog settings dictionary
-mongodb_conf_verbosity: 1                              # Verbosity when mongodb_conf_logging_defaults is used
 mongodb_conf_maxConns: 800                             # Max number of simultaneous connections
 mongodb_conf_port: 27017                               # Specify TCP port number
 mongodb_conf_oplogSize: 1024

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,8 @@ mongodb_conf_cpu: yes                                  # Periodically show cpu a
 mongodb_conf_httpInterface: false                      # Enable (deprecated) http interface
 mongodb_conf_ipv6: false                               # Enable IPv6 support
 mongodb_conf_journal: true                             # Enable journaling
-mongodb_conf_logging: "{{ mongodb_conf_logging_defaults }}" # systemLog settings dictionary
+mongodb_conf_logging:                                  # systemLog settings dictionary
+  verbosity: 0
 mongodb_conf_maxConns: 800                             # Max number of simultaneous connections
 mongodb_conf_port: 27017                               # Specify TCP port number
 mongodb_conf_oplogSize: 1024

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -37,4 +37,4 @@ storage:
       cacheSizeGB: 1
 
 systemLog:
-  verbosity: {{ mongodb_conf_verbosity }}
+{{ mongodb_conf_logging | to_nice_yaml | indent(2, true) }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+# https://docs.mongodb.com/manual/reference/configuration-options/#systemlog-options
+mongodb_conf_logging_defaults:
+  verbosity: "{{ mongodb_conf_verbosity }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
 # https://docs.mongodb.com/manual/reference/configuration-options/#systemlog-options
 mongodb_conf_logging_defaults:
-  verbosity: "{{ mongodb_conf_verbosity }}"
+  verbosity: 1

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
-# https://docs.mongodb.com/manual/reference/configuration-options/#systemlog-options
-mongodb_conf_logging_defaults:
-  verbosity: 1


### PR DESCRIPTION
There are quite a lot [systemLog](https://docs.mongodb.com/manual/reference/configuration-options/#systemlog-options) options and defining variables for all of them would be impractical. This PR adds support for defining the whole dictionary so that any option can be set. Usage might not be obvious so I added a small example in the readme file.

A backwards compatible default value is provided so that this enhancement shouldn't change anything on existing setups.

I noticed that `mongodb_conf_sysLog` option wasn't used so I removed it.

