### PR TITLE
Add virtualenv support for molecule testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 molecule/default/.molecule
+.venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ services:
   - docker
 language: python
 before_install:
+  - deactivate
+  - sudo pip install docker-py
+  - source ~/virtualenv/python2.7/bin/activate
   - ln -s $TRAVIS_BUILD_DIR $(dirname "$TRAVIS_BUILD_DIR")/$ROLE_NAME
-  - pip install molecule docker-py ansible
+  - pip install molecule ansible
   - molecule dependency
 script:
   - molecule converge -s default

--- a/README.md
+++ b/README.md
@@ -68,16 +68,22 @@ the configs on `defaults/main.yml` and they will be (hopefully) applied to your 
 
 ## Testing
 This role implements unit tests with [Molecule](https://molecule.readthedocs.io/) on Docker. Notice that we only
-support Molecule 2.0 or greater. You can install molecule with:
+support Molecule 2.0 or greater. You can install molecule locally with:
 ```bash
+virtualenv .venv
+.venv/bin/activate
 pip install molecule
 ```
 The Docker installation and configuration is out of scope.
 
-After having Molecule setup, you can run the tests with:
+After having Molecule setup within the virtualenv, you can run the tests with:
 ```bash
 molecule converge
 ```
+
+If you have a SELinux-enabled host, you must have the libselinux-python library installed. In Fedora 28, the RPM
+package is named python2-libselinux. There's a special addition in the Molecule playbook when delegating tasks to
+localhost to use the host's python instead of the virtualenv python in order to properly access the SELinux bindings.
 
 ## Contributing
 Just open a PR. We love PRs!

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -8,6 +8,7 @@
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+    ansible_python_interpreter: "/usr/bin/python"
   tasks:
     - name: Create Dockerfiles from image names
       template:


### PR DESCRIPTION
This PR enables Molecule to run within a virtualenv environment even in a system with SELinux enabled, and adds instructions to create such virtualenv.