### PR TITLE
Update OS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ To conserve development efforts, we decided that a supported distro should:
 Therefore, the supported systems list is currently:
 
 * Enterprise Linux (both CentOS and RHEL)
-  * 7.2
   * 7.3
   * 7.4
 * Ubuntu

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Therefore, the supported systems list is currently:
 * Enterprise Linux (both CentOS and RHEL)
   * 7.3
   * 7.4
+  * 7.5
 * Ubuntu
   * 16.04
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,12 @@ driver:
 lint:
   name: yamllint
 platforms:
+  - name: centos7_5
+    image: centos:7.5.1804
+    command: /usr/sbin/init
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: centos7_4
     image: centos:7.4.1708
     command: /usr/sbin/init

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,12 +18,6 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  - name: centos7_2
-    image: centos:7.2.1511
-    command: /usr/sbin/init
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: xenial
     image: ubuntu:xenial
     command: /sbin/init


### PR DESCRIPTION
In this PR we add support for RHEL7.5 that was recently released, and drop support for RHEL7.2 that went out of Extended Update Support from Red Hat November 30.

We haven't added support for Ubuntu 18.04 Bionic Beaver since MongoDB.org hasn't yet added official support for this release and hasn't provided an official repository for it. [Is is planned for the 4.0 release later this year.](https://jira.mongodb.org/browse/SERVER-33000?focusedCommentId=1876796&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1876796)