### PR TITLE
Introduce MongoDB 3.6 support and use it by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 mongodb_install_enabled: true
 mongodb_install_selinux: true
 mongodb_install_major: 3
-mongodb_install_minor: 4
+mongodb_install_minor: 6
 mongodb_install_patch: "*"
 
 mongodb_daemon_bin: /usr/bin/mongod

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,7 +1,10 @@
 - name: Import the key for the official MongoDB repository.
   apt_key:
     keyserver: hkp://keyserver.ubuntu.com:80
-    id: 0C49F3730359A14518585931BC711F9BA15703C6
+    id: "{{ item }}"
+  with_items:
+    - 0C49F3730359A14518585931BC711F9BA15703C6 #MongoDB 3.4
+    - 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 #MongoDB 3.6
 
 - name: Setup Debian MongoDB {{ mongodb_install_major }}.{{ mongodb_install_minor }} repository
   copy:

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -3,8 +3,10 @@
 
 net:
   bindIp: {{ '127.0.0.1' if mongodb_safeMode else mongodb_conf_bindIp }}
+{% if mongodb_install_major <= 3 and mongodb_install_minor < 6 %}
   http:
     enabled: {{ mongodb_conf_httpInterface|to_nice_json|bool|lower }}
+{% endif %}
   ipv6: {{ mongodb_conf_ipv6|to_nice_json|bool|lower }}
   maxIncomingConnections: {{ mongodb_conf_maxConns|int }}
   port: {{ mongodb_conf_port|int }}
@@ -13,18 +15,18 @@ processManagement:
   fork: false
   pidFilePath: {{ mongodb_conf_pidFile }}
 
-{% if mongodb_replSet_enabled and not mongodb_safeMode -%}
+{% if mongodb_replSet_enabled and not mongodb_safeMode %}
 replication:
   oplogSizeMB: {{ mongodb_conf_oplogSize | int }}
   replSetName: {{ mongodb_replSet_name }}
 {% endif %}
 
-{% if mongodb_conf_auth and not mongodb_safeMode -%}
+{% if mongodb_conf_auth and not mongodb_safeMode %}
 security:
   authorization: {{ 'enabled' if mongodb_conf_auth else 'disabled' }}
-  {% if mongodb_replSet_enabled and mongodb_conf_auth -%}
+{% if mongodb_replSet_enabled and mongodb_conf_auth %}
   keyFile: {{ mongodb_conf_keyFile }}
-  {% endif %}
+{% endif %}
 {% endif %}
 
 storage:


### PR DESCRIPTION
This PR introduces the needed changes to support MongoDB 3.6, including necessarily not writing the HTTP API interface setting in the config file and adding the necessary APT signing keys, and make it the default choice when the version variables arent overridden.