### PR TITLE
Move EPEL install to prepare step

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,6 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: stone-payments.epel
-      when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
     - role: stone-payments.mongodb

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,5 +1,7 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
+  roles:
+    - role: stone-payments.epel
+      when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
   tasks: []

--- a/molecule/replica-set/playbook.yml
+++ b/molecule/replica-set/playbook.yml
@@ -10,6 +10,4 @@
     #mongodb_replSet_key: "testLonger"
 
   roles:
-   - role: stone-payments.epel
-     when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
    - role: stone-payments.mongodb

--- a/molecule/security/playbook.yml
+++ b/molecule/security/playbook.yml
@@ -3,8 +3,6 @@
   hosts: all
   become: true
   roles:
-    - role: stone-payments.epel
-      when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
     - role: stone-payments.mongodb
   vars:
     mongodb_conf_bindIp: "0.0.0.0"

--- a/molecule/security/prepare.yml
+++ b/molecule/security/prepare.yml
@@ -1,8 +1,10 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: False
   become: true
+  roles:
+    - role: stone-payments.epel
+      when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
   tasks:
     - name: test if firewalld unit is loaded
       shell: systemctl show firewalld --property=LoadState


### PR DESCRIPTION
This PR moves the EPEL install step on tests to the prepare playbook, in order to make an even more close to reality playbook, matching the README.