### PR TITLE
Add vars to support enabling yum repository and pip custom index.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,3 +47,5 @@ mongodb_shell_commands: {}                             # Define mongo shell comm
                                                        #           - db.setProfilingLevel(1, 50)
 
 mongodb_safeMode: false
+mongodb_enable_yum_repository: true
+mongodb_pip_index_url: ""

--- a/tasks/install.common.yml
+++ b/tasks/install.common.yml
@@ -2,7 +2,15 @@
   pip:
     name: pymongo
     state: latest
-
+  when:  mongodb_pip_index_url == ""
+    
+- name: install pymongo from custom index
+  pip:
+    name: pymongo
+    state: latest
+    extra_args: -i "{{ mongodb_pip_index_url }}"
+  when:  mongodb_pip_index_url|default("") != "" 
+  
 - name: remove old broken sysV script
   file:
     path: "/etc/rc.d/init.d/mongod"

--- a/tasks/install.rpm.yml
+++ b/tasks/install.rpm.yml
@@ -24,6 +24,7 @@
   rpm_key:
     state: present
     key: "https://www.mongodb.org/static/pgp/server-{{ mongodb_install_major }}.{{ mongodb_install_minor }}.asc"
+  when: mongodb_enable_yum_repository
 
 - name: install MongoDB {{ mongodb_install_major }}.{{ mongodb_install_minor }} repo
   yum_repository:
@@ -32,6 +33,7 @@
     baseurl: "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ mongodb_install_major }}.{{ mongodb_install_minor }}/$basearch/"
     gpgcheck: true
     state: present
+  when: mongodb_enable_yum_repository
 
 - name: install MongoDB package
   yum: name={{item}} state=present


### PR DESCRIPTION
This PR adds the variable mongodb_enable_yum_repository to define when the role must add the public repo or not. 
Also, this PR adds a condition to define when the role must install pymongo from a custom index. For this, it was necessary adds the variable mongodb_pip_index_url.